### PR TITLE
Correct artisan example syntax in commands admin documentation

### DIFF
--- a/content/docs/admin/commands.md
+++ b/content/docs/admin/commands.md
@@ -5,7 +5,7 @@ date = "2017-02-26"
 type = "admin-docs"
 +++
 
-BookStack has some command line actions that can help with maintenence and common operations. There are also many commands available from the undlying Laravel framework. To list all available commands you can simply run `php artian` from your BookStack install folder. Custom BookStack commands are all under the 'bookstack' namespace.
+BookStack has some command line actions that can help with maintenence and common operations. There are also many commands available from the undlying Laravel framework. To list all available commands you can simply run `php artisan` from your BookStack install folder. Custom BookStack commands are all under the 'bookstack' namespace.
 
 ### BookStack Commands
 


### PR DESCRIPTION
Corrects just one minor typo of the artisan command in the docs. Great work on BookStack, I will try to play around with it more later!