### PR TITLE
Adding a Mail Configuration page to the admin documentation.

### DIFF
--- a/content/docs/admin/mail-config.md
+++ b/content/docs/admin/mail-config.md
@@ -6,8 +6,6 @@ type = "admin-docs"
 slug = "mail-config"
 +++
 
-This document has been written by referencing the file at `config/mail.php`.
-
 Bookstack supports the following mechanisms for sending mail:
 
 1. SMTP;

--- a/content/docs/admin/mail-config.md
+++ b/content/docs/admin/mail-config.md
@@ -6,6 +6,8 @@ type = "admin-docs"
 slug = "mail-config"
 +++
 
+This document has been written by referencing the file at `config/mail.php`.
+
 Bookstack supports the following mechanisms for sending mail:
 
 1. SMTP;
@@ -16,7 +18,7 @@ Bookstack supports the following mechanisms for sending mail:
 6. Amazon SES ('ses'); or
 7. Log
 
-# SMTP Configuration
+# SMTP
 
 To get up and running with SMTP, you will need the following variables - Example
 values have been provided below:
@@ -36,3 +38,55 @@ MAIL_PASSWORD=onlyifneeded
 # MAIL_FROM - The email address Bookstack uses to send emails.
 MAIL_FROM=noreply@yourdomain.tld  
 ```
+
+# mail and sendmail
+
+The `mail` and `sendmail` drivers use the variables listed in the SMTP section,
+however they use different methods to actually send the email, and connect to
+the SMTP gateway:
+
+* `mail` uses the PHP mail() function;
+* `sendmail` uses the Linux application - It calls `/usr/sbin/sendmail -bs`.
+
+# Mailgun / Mandrill / Amazon SES
+
+These web services are configured via the `config/services.php` file.
+At present Bookstack does not have environment variables support for these.
+
+## Mailgun
+
+Mailgun requires:
+
+* A domain as configured within the Mailgun configuration portal; and
+* An API secret for the domain.
+```PHP
+'mailgun'  => [
+  'domain' => '',
+  'secret' => '',
+],
+```
+
+## Mandrill
+
+At time of writing, Mandrill only requires a 'secret'.
+```PHP
+'mandrill' => [
+  'secret' => '',
+],
+```
+
+## Amazon SES
+
+SES requires three keys to be set:
+```PHP
+'ses'      => [
+    'key'    => '',
+    'secret' => '',
+    'region' => 'us-east-1',
+],
+```
+
+# The 'log' mail driver
+
+This driver outputs the mail to the application log, and is useful for local
+development instances.

--- a/content/docs/admin/mail-config.md
+++ b/content/docs/admin/mail-config.md
@@ -11,9 +11,6 @@ Bookstack supports the following mechanisms for sending mail:
 1. SMTP;
 2. mail (php sendmail() function);
 3. sendmail (Linux sendmail);
-4. Mailgun (Rackspace Mailgun);
-5. Mandrill; or
-6. Amazon SES ('ses')
 
 # SMTP
 
@@ -45,40 +42,14 @@ the SMTP gateway:
 * `mail` uses the PHP mail() function;
 * `sendmail` uses the Linux application - It calls `/usr/sbin/sendmail -bs`.
 
-# Mailgun / Mandrill / Amazon SES
+# Other Mechanisms
 
-These web services are configured via the `config/services.php` file.
-At present Bookstack does not have environment variables support for these.
+These mechanisms are not fully supported, but are reported to work.
 
-## Mailgun
+| Service           | Driver Name |
+|-------------------|-------------|
+| Amazon SES        | ses         |
+| Mandrill          | mandrill    |
+| Rackspace Mailgun | mailgun     |
 
-Mailgun requires:
-
-* A domain as configured within the Mailgun configuration portal; and
-* An API secret for the domain.
-```PHP
-'mailgun'  => [
-  'domain' => '',
-  'secret' => '',
-],
-```
-
-## Mandrill
-
-At time of writing, Mandrill only requires a 'secret'.
-```PHP
-'mandrill' => [
-  'secret' => '',
-],
-```
-
-## Amazon SES
-
-SES requires three keys to be set:
-```PHP
-'ses'      => [
-    'key'    => '',
-    'secret' => '',
-    'region' => 'us-east-1',
-],
-```
+Refer to `config/services.php` for configuration hints.

--- a/content/docs/admin/mail-config.md
+++ b/content/docs/admin/mail-config.md
@@ -12,9 +12,8 @@ Bookstack supports the following mechanisms for sending mail:
 2. mail (php sendmail() function);
 3. sendmail (Linux sendmail);
 4. Mailgun (Rackspace Mailgun);
-5. Mandrill;
-6. Amazon SES ('ses'); or
-7. Log
+5. Mandrill; or
+6. Amazon SES ('ses')
 
 # SMTP
 
@@ -83,8 +82,3 @@ SES requires three keys to be set:
     'region' => 'us-east-1',
 ],
 ```
-
-# The 'log' mail driver
-
-This driver outputs the mail to the application log, and is useful for local
-development instances.

--- a/content/docs/admin/mail-config.md
+++ b/content/docs/admin/mail-config.md
@@ -1,0 +1,38 @@
++++
+title = "Mail Configuration"
+description = "Configuring Bookstack to send mail"
+date = "2017-08-08"
+type = "admin-docs"
+slug = "mail-config"
++++
+
+Bookstack supports the following mechanisms for sending mail:
+
+1. SMTP;
+2. mail (php sendmail() function);
+3. sendmail (Linux sendmail);
+4. Mailgun (Rackspace Mailgun);
+5. Mandrill;
+6. Amazon SES ('ses'); or
+7. Log
+
+# SMTP Configuration
+
+To get up and running with SMTP, you will need the following variables - Example
+values have been provided below:
+
+Generally speaking, if a value is not required (such as MAIL_PORT variable), it
+can be set to 'null', or not defined and a default will be chosen.
+
+The list below shows all the supported options for SMTP.
+
+```bash
+MAIL_DRIVER=smtp
+MAIL_HOST=smtp.provider.tld
+MAIL_PORT=465
+MAIL_ENCRYPTION=tls
+MAIL_USERNAME=user@provider.tld
+MAIL_PASSWORD=onlyifneeded
+# MAIL_FROM - The email address Bookstack uses to send emails.
+MAIL_FROM=noreply@yourdomain.tld  
+```

--- a/content/docs/admin/mail-config.md
+++ b/content/docs/admin/mail-config.md
@@ -44,7 +44,9 @@ the SMTP gateway:
 
 # Other Mechanisms
 
-These mechanisms are not fully supported, but are reported to work.
+These mechanisms are not supported, but are reported to work.
+At present they may require additional dependencies in order to function
+reliably.
 
 | Service           | Driver Name |
 |-------------------|-------------|


### PR DESCRIPTION
After a bit of head-scratching and searching myself, thought I'd make it a bit easier to find the information required to set up an instance of Bookstack with mail providers.

Open to feedback!