### PR TITLE
Adding that SimpleXML and DOM are also needed.

### DIFF
--- a/content/docs/admin/installation.md
+++ b/content/docs/admin/installation.md
@@ -19,7 +19,7 @@ Below are some different methods of installing BookStack. If you cannot find a g
 BookStack has similar requirements to Laravel:
 
 * PHP >= 7.0.0, Will need to be usable from the command line.
-* PHP Extensions: `OpenSSL`, `PDO`, `MBstring`, `Tokenizer`, `GD`, `MySQLND`, `Tidy`
+* PHP Extensions: `OpenSSL`, `PDO`, `MBstring`, `Tokenizer`, `GD`, `MySQLND`, `Tidy`, `SimpleXML`, `DOM`
 * MySQL >= 5.6, Single DB *(All permissions advised since application manages schema)*
 * Git *(Not strictly required but helps manage updates)*
 * [Composer](https://getcomposer.org/)


### PR DESCRIPTION
Was installing this on Debian 9 today and got this error,
```
Problem 1
- Installation request for aws/aws-sdk-php 3.52.6 -> satisfiable by aws/aws-sdk-php[3.52.6].
- aws/aws-sdk-php 3.52.6 requires ext-simplexml * -> the requested PHP extension simplexml is missing from your system.
Problem 2
- Installation request for dompdf/dompdf v0.8.2 -> satisfiable by dompdf/dompdf[v0.8.2].
- dompdf/dompdf v0.8.2 requires ext-dom * -> the requested PHP extension dom is missing from your system.
Problem 3
- Installation request for phar-io/manifest 1.0.1 -> satisfiable by phar-io/manifest[1.0.1].
- phar-io/manifest 1.0.1 requires ext-dom * -> the requested PHP extension dom is missing from your system.
Problem 4
- Installation request for phpunit/php-code-coverage 5.3.0 -> satisfiable by phpunit/php-code-coverage[5.3.0].
- phpunit/php-code-coverage 5.3.0 requires ext-dom * -> the requested PHP extension dom is missing from your system.
Problem 5
- Installation request for phpunit/phpunit 6.5.6 -> satisfiable by phpunit/phpunit[6.5.6].
- phpunit/phpunit 6.5.6 requires ext-dom * -> the requested PHP extension dom is missing from your system.
Problem 6
- Installation request for squizlabs/php_codesniffer 3.2.2 -> satisfiable by squizlabs/php_codesniffer[3.2.2].
- squizlabs/php_codesniffer 3.2.2 requires ext-simplexml * -> the requested PHP extension simplexml is missing from your system.
Problem 7
- Installation request for theseer/tokenizer 1.1.0 -> satisfiable by theseer/tokenizer[1.1.0].
- theseer/tokenizer 1.1.0 requires ext-dom * -> the requested PHP extension dom is missing from your system.
Problem 8
- aws/aws-sdk-php 3.52.6 requires ext-simplexml * -> the requested PHP extension simplexml is missing from your system.
- league/flysystem-aws-s3-v3 1.0.18 requires aws/aws-sdk-php ^3.0.0 -> satisfiable by aws/aws-sdk-php[3.52.6].
- Installation request for league/flysystem-aws-s3-v3 1.0.18 -> satisfiable by league/flysystem-aws-s3-v3[1.0.18].
```