### PR TITLE
Add shell script for backups to documentation

### DIFF
--- a/content/docs/admin/backup-restore.md
+++ b/content/docs/admin/backup-restore.md
@@ -158,4 +158,7 @@ tar -czf "$TODAY_BACKUP_DIR"files.tar.gz .env public/uploads storage/uploads
 
 cd $BACKUP_DIR
 tar -czf $ARTIFACT $TODAY_BACKUP_DIR
+
+# Do what ever you need with the backup artifact.
+
 ```


### PR DESCRIPTION
I had to implement a script to backup book stack, thought it might help.