### PR TITLE
Added caveat for role renaming

### DIFF
--- a/content/docs/admin/ldap-auth.md
+++ b/content/docs/admin/ldap-auth.md
@@ -81,7 +81,7 @@ LDAP_ID_ATTRIBUTE=BIN;objectGUID
 BookStack has the ability to sync LDAP user groups with BookStack roles. By default this will match LDAP group names with the BookStack role display names with casing ignored.
 This can be overridden by via the 'External Authentication IDs' field which can be seen when editing a role while LDAP authentication is enabled. This field can be populated with common names (CNs) of accounts *or* groups. If filled, CNs in this field will be used and the role name will be ignored. You can match on multiple CNs by separating them with a comma.
 
-When matching LDAP groups with role names or 'External Authentication IDs' values, BookStack will standardise the names of ldap groups to be lower-cased and spaces will be replaced with hypens. For example, to match a LDAP group named "United Kingdom" an 'External Authentication IDs' value of "united-kingdom" could be used.
+When matching LDAP groups with role names or 'External Authentication IDs' values, BookStack will standardise the names of ldap groups to be lower-cased and spaces will be replaced with hypens. For example, to match a LDAP group named "United Kingdom" an 'External Authentication IDs' value of "united-kingdom" could be used. You must create new roles for this function to work. You cannot rename the default roles.
 
 This feature requires the LDAP server to be able to provide user groups when queried. This is enabled by default on ActiveDirectory via the 'memberOf' attribute but other LDAP systems may need to be configured to enable such functionality. If using OpenLDAP you'll need to setup the memberof overlay.
 


### PR DESCRIPTION
It appears that renaming the default roles to the expected LDAP group matches does not have the intended outcome.  Creating new roles works, though. For example, renaming the default BookStack role "Editor" to "users" should map to the LDAP group "users". But it does not. Creating a new BookStack role "users", however, works as intended.