### PR TITLE
Added info about primary group missing

### DIFF
--- a/content/docs/admin/ldap-auth.md
+++ b/content/docs/admin/ldap-auth.md
@@ -83,7 +83,7 @@ This can be overridden by via the 'External Authentication IDs' field which can 
 
 When matching LDAP groups with role names or 'External Authentication IDs' values, BookStack will standardise the names of ldap groups to be lower-cased and spaces will be replaced with hypens. For example, to match a LDAP group named "United Kingdom" an 'External Authentication IDs' value of "united-kingdom" could be used.
 
-This feature requires the LDAP server to be able to provide user groups when queried. This is enabled by default on ActiveDirectory via the 'memberOf' attribute but other LDAP systems may need to be configured to enable such functionality. If using OpenLDAP you'll need to setup the memberof overlay.
+This feature requires the LDAP server to be able to provide user groups when queried. This is enabled by default on ActiveDirectory via the 'memberOf' attribute but other LDAP systems may need to be configured to enable such functionality. Be aware that the 'memberOf' attribute does not include the user's primary group. If using OpenLDAP you'll need to setup the memberof overlay.
 
 Here are the settings required to be added to your `.env` file to enable group syncing:
 


### PR DESCRIPTION
The memberof attribute does not include the user's primary group. Usually it is simply set to 'domain users', but ours was set to the same group we used to autoassign groups in bookstack.
Ref: https://ldapwiki.com/wiki/MemberOf