### PR TITLE
Improved note on requirements for manual installation

### DIFF
--- a/content/docs/admin/installation.md
+++ b/content/docs/admin/installation.md
@@ -47,7 +47,7 @@ BookStack does not currently support shared PHP hosting. There are too many diff
 
 ## Manual Installation
 
-Ensure the above requirements are met before installing.
+>**ATTENTION** <br> Ensure the above [requirements](#requirements) are met before installing. This includes required PHP extensions.
 
 This project currently uses the `release` branch of the BookStack GitHub repository as a stable channel for providing updates. The installation is currently somewhat complicated and will be made simpler in future releases. Some PHP or Laravel experience will make this easier.
 


### PR DESCRIPTION
Improved visibility of necessary requirements for manual installation by adding a direct link at the beginning of the section to the requirements section since that is read over quite easily