### PR TITLE
Update language configuration

### DIFF
--- a/content/docs/admin/language-config.md
+++ b/content/docs/admin/language-config.md
@@ -33,7 +33,7 @@ The value of the `APP_LANG` variable must be a valid locale code matching one of
 * German (Informal) - `de_informal`
 * Italian - `it`
 * Japanese - `ja`
-* Korean - `kr`
+* Korean - `ko`
 * Polish - `pl`
 * Russian - `ru`
 * Slovakian - `sk`


### PR DESCRIPTION
It seems `ko` is right.