### PR TITLE
Added Ubuntu 22.04 install script instructions

### DIFF
--- a/content/blog/ubuntu-2204-script.md
+++ b/content/blog/ubuntu-2204-script.md
@@ -1,0 +1,33 @@
++++
+categories = ["News"]
+tags = ["News"]
+title = "Ubuntu 22.04 BookStack Install Script Now Available"
+date = 2022-04-21T15:30:00Z
+author = "Dan Brown"
+image = "/images/blog-cover-images/jellyfish-ruthlaine-tan.jpg"
+slug = "ubuntu-2204-script"
+draft = false
++++
+
+To support today's release of the next LTS version of Ubuntu, 22.04 (Jammy Jellyfish),
+we have added a new BookStack install script for users of this OS:
+
+[Find script details here](/docs/admin/installation/#ubuntu-2204).
+
+Relative to our previous Ubuntu LTS scripts, this 22.04 script introduces a series of improvements including:
+
+- Setting of file/folder permissions based upon the user running the script (Instead of just applying root permissions).
+- Writing of script command output to a file by default, for easier debugging.
+- Simpler command line output to user with clear indication of progress.
+- Checks to ensure a sudo/privileged user is used to run the script.
+- Checks for existing MySQL/Apache usage to prevent conflicts.
+
+Overall these changes provide a much simpler & stable install experience. This following CLI recording shows the improved process (with some steps sped-up):
+
+
+<script id="asciicast-489055" src="https://asciinema.org/a/489055.js" async></script>
+
+----
+
+<span style="font-size: 0.8em;opacity:0.9;">Header Image Credits: <span>Photo by <a href="https://unsplash.com/@ruthlainezz?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Ruthlaine Tan</a> on <a href="https://unsplash.com/s/photos/jellyfish?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
+  </span></span>

--- a/content/docs/admin/installation.md
+++ b/content/docs/admin/installation.md
@@ -11,6 +11,7 @@ Below you can find details on how to install BookStack on your own hosting. Ther
 * [Shared Hosting](#shared)
 * [Manual](#manual)
 * [Docker](#docker)
+* [Ubuntu 22.04 Script](#ubuntu-2204)
 * [Ubuntu 20.04 Script](#ubuntu-2004)
 * [Ubuntu 18.04 Script](#ubuntu-1804)
 * [Community Guides](#community)
@@ -28,7 +29,7 @@ BookStack has the following requirements:
 * **PHP** >= 7.4
     * For installation and maintenance, you'll need to be able to run `php` from the command line.
     * Required Extensions: *OpenSSL, PDO, MBstring, Tokenizer, GD, MySQL, SimpleXML & DOM*
-* **MySQL** >= 5.6 or **MariaDB** >= 10.0
+* **MySQL** >= 5.7 or **MariaDB** >= 10.2
     * For the storage of BookStack content and data.
     * Single Database *(All permissions advised since application manages schema)*
 * **Git Version Control**
@@ -91,6 +92,34 @@ Community docker setups are available for those that would prefer to use a conta
 
 * [GitHub Repository](https://github.com/solidnerd/docker-bookstack)
 * [Docker Hub page](https://hub.docker.com/r/solidnerd/bookstack/)
+
+---
+
+<a name="ubuntu-2204"></a>
+
+## Ubuntu 22.04 Installation Script
+
+A script to install BookStack on a fresh instance of Ubuntu 22.04 is available. This script is ONLY FOR A FRESH OS, it will install Apache, MySQL 8.0 & PHP-8.1 and could OVERWRITE any existing web setup on the machine. It also does not set up mail settings or configure system security so you will have to do those separately. You can use the script as a reference if you're installing on a non-fresh machine.
+
+[Link to installation script](https://github.com/BookStackApp/devops/blob/main/scripts/installation-ubuntu-22.04.sh)
+
+#### Running the Script
+
+```bash
+# Ensure you have read the above information about what this script does before executing these commands.
+
+# Download the script
+wget https://raw.githubusercontent.com/BookStackApp/devops/main/scripts/installation-ubuntu-22.04.sh
+
+# Make it executable
+chmod a+x installation-ubuntu-22.04.sh
+
+# Run the script with admin permissions
+sudo ./installation-ubuntu-22.04.sh
+```
+
+The script will output a log file for debugging within your current working directory when running the script.
+Permissions for the BookStack installation files & folders will be set based upon the user used to run the script.
 
 ---
 

--- a/static/images/blog-cover-images/jellyfish-ruthlaine-tan.jpg
+++ b/static/images/blog-cover-images/jellyfish-ruthlaine-tan.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df7dc58c439255a1ea5a005889a6c343fd11a23daf505ac7892940a2a00062a3
+size 291232


### PR DESCRIPTION
Also bumped database requirements to oldest supported versions since those had not changed for many years.

Related to https://github.com/BookStackApp/devops/pull/35