### PR TITLE
Add PikaPods as additional hosting option, sort.

### DIFF
--- a/content/docs/admin/installation.md
+++ b/content/docs/admin/installation.md
@@ -199,6 +199,7 @@ _**Note: These are not tested, vetted nor supported by the official BookStack pr
 - [Home Assistant Community Add-on](https://github.com/hassio-addons/addon-bookstack) - For [Home Assistant](https://www.home-assistant.io/) users.
 - [Stellar Hosted](https://www.stellarhosted.com/bookstack/) - A European based managed hosting provider.
 - [alwaysdata](https://www.alwaysdata.com/en/marketplace/bookstack/) - A European based managed hosting provider.
+- [PikaPods](https://www.pikapods.com/pods?run=bookstack) - Managed open source hosting, EU and US regions available.
 
 ---
 


### PR DESCRIPTION
This adds [PikaPods](https://www.pikapods.com/) as hosting option.

About PikaPods: Aims to make great open source apps, like BookStack more accessible and easier to get started with. We already offer BookStack in our “[app store](https://www.pikapods.com/apps)” and dozens of users are already running it.

So I'm suggesting to add PikaPods as additional option to run BookStack. This would help an even wider audience to benefit from the project.

Thanks!