### PR TITLE
Change `tls` to `ssl`

### DIFF
--- a/content/docs/admin/email-webhooks.md
+++ b/content/docs/admin/email-webhooks.md
@@ -30,7 +30,7 @@ MAIL_DRIVER=smtp
 # Host, Port & Encryption mechanism to use
 MAIL_HOST=smtp.provider.tld
 MAIL_PORT=465
-MAIL_ENCRYPTION=tls
+MAIL_ENCRYPTION=ssl
 
 # Authentication details for your SMTP service
 MAIL_USERNAME=user@provider.tld


### PR DESCRIPTION
When attempting to configure smtp mail delivery, I kept running into timeout issues when connecting to my email server. After resolving an issue with docker networking on AlmaLinux 9, further Googling showed `tls` should be changed for `ssl` within Laravel 6.x and higher.

More information can be found here where I learned the solution: https://stackoverflow.com/questions/38341424/connection-to-tcp-smtp-mail-yahoo-com465-timed-out

Hoping this helps others out who run into the same issue :)