### PR TITLE
Patch php upgrade notes

### DIFF
--- a/content/blog/bookstack-release-v23-02.md
+++ b/content/blog/bookstack-release-v23-02.md
@@ -18,7 +18,7 @@ a few other additions.
 
 **Upgrade Notices**
 
-- **PHP Version Requirement Change** - The minimum supported PHP version has changed from PHP 7.4 to PHP 8.0.2 in this release. Please see the [v23.02 version-specific update instructions](/docs/admin/updates/#updating-to-v2302-or-higher) for guidance on updating PHP. 
+- **PHP Version Requirement Change** - The minimum supported PHP version has changed from PHP 7.4 to PHP 8.2 in this release. Please see the [v23.02 version-specific update instructions](/docs/admin/updates/#updating-to-v2302-or-higher) for guidance on updating PHP. 
 - **Logical Theme System Event Change** - The `commonmark_environment_configure` event argument and return types have changed. Please [see the event definition](https://github.com/BookStackApp/BookStack/blob/b88b1bef2c0cf74627c5122b656dfabc2d5f23ee/app/Theming/ThemeEvents.php#L63-L71) to understand the new types if using this logical theme system event.
 
 {{<yt pn9GnHWyQ_g>}}

--- a/content/docs/admin/installation.md
+++ b/content/docs/admin/installation.md
@@ -26,7 +26,7 @@ Below you can find details on how to install BookStack on your own hosting. Ther
 
 BookStack has the following requirements:
 
-* **PHP** >= 8.0.2
+* **PHP** >= 8.2
     * For installation and maintenance, you'll need to be able to run `php` from the command line.
     * Required Extensions: *OpenSSL, PDO, MBstring, Tokenizer, GD, MySQL, SimpleXML & DOM*
 * **MySQL** >= 5.7 or **MariaDB** >= 10.2

--- a/content/docs/admin/updates.md
+++ b/content/docs/admin/updates.md
@@ -41,7 +41,7 @@ the [GitHub releases page](https://github.com/BookStackApp/BookStack/releases).
 
 #### Updating to v23.02 or higher
 
-**PHP Version Requirement Change** - The minimum required version of PHP has changed from 7.4 to 8.0.2. This should not be a concern for those that are using common containers. Installations via our Ubuntu 22.04 install script are already using PHP 8.1 and therefore they don't need to be upgraded at this time.
+**PHP Version Requirement Change** - The minimum required version of PHP has changed from 7.4 to 8.2. This should not be a concern for those that are using common containers. Installations via our Ubuntu 22.04 install script are already using PHP 8.1 and therefore they don't need to be upgraded at this time.
 
 For installs that have used our Ubuntu 18.04 and Ubuntu 20.04 install scripts, PHP can generally be upgraded to 8.2 using the below commands:
 


### PR DESCRIPTION
Hi Dan,

I noticed when looking at your upgrade notes that you have dropped PHP 7.4 and moved to a minimum of PHP 8.0.2 . I initially felt - OK! Minimum version is now PHP 8.0.x but later on in documentation noted that PHP 8.2 was referenced.

This very basic PR makes 3 changes to files to support a PHP 8.2.x Minimum.

If you meant PHP 8.0.x then we can ignore, however the the latest version of that release is actually [8.0.28](https://www.php.net/downloads).

Thanks for the release, looking forward to utilizing.
