### PR TITLE
Small typo fixes: "it's" vs "its"

### DIFF
--- a/content/about/confluence-alternative.md
+++ b/content/about/confluence-alternative.md
@@ -19,7 +19,7 @@ Tired of seeing placeholder content while your pages load? Tired of managing blo
 
 ##### WYSIWYG Editing Experience
 
-BookStack uses a WYSWIYG editor at it's core, with a range of essential formatting options and features. No scary mark-up language. Ideal for mixed-skill environments.
+BookStack uses a WYSWIYG editor at its core, with a range of essential formatting options and features. No scary mark-up language. Ideal for mixed-skill environments.
 
 ##### Standard Content Storage Format
 

--- a/content/about/open-source-documentation-software.md
+++ b/content/about/open-source-documentation-software.md
@@ -43,7 +43,7 @@ loses access in an effort to reduce costs. Nor would you want to promote insecur
 (such as user account sharing) to meet user limits.
 
 Speaking of insecure practices, we don't charge extra for advanced authentication features
-like many paid services do. Once something is added to the core code-base, its available
+like many paid services do. Once something is added to the core code-base, it's available
 to all. Features like SAML2, LDAP and multi-factor-auth are baked into the platform.
 
 ### Customize to Requirements

--- a/content/about/teams-wiki-alternative.md
+++ b/content/about/teams-wiki-alternative.md
@@ -19,7 +19,7 @@ These also have the ability to map BookStack user roles to auth system groups fo
 
 BookStack is built to be self-hosted and it can be done so without needing a great deal of resources.
 It's fundamentally a modern PHP application using MySQL as a datastore. 
-It can easily be ran on a 1GB RAM VM, and it's resource usage scales with system activity. 
+It can easily be ran on a 1GB RAM VM, and its resource usage scales with system activity. 
 
 ##### WYSIWYG Editor Experience, Markdown for Power Users
 

--- a/content/blog/5-years-of-bookstack.md
+++ b/content/blog/5-years-of-bookstack.md
@@ -68,7 +68,7 @@ Growth since January 2016:
 
 #### Thoughts
 
-I've always kept an eye on GitHub stars, so its satisfying to hit the 5k mark at the same time as hitting 5 years. The GitHub stars have been slowly accelerating. The [first 1k](https://www.bookstackapp.com/blog/1k-stars-and-v0-19-0/) took about 2 years & 3 months to accrue, whereas we hit 4k only in February this year.
+I've always kept an eye on GitHub stars, so it's satisfying to hit the 5k mark at the same time as hitting 5 years. The GitHub stars have been slowly accelerating. The [first 1k](https://www.bookstackapp.com/blog/1k-stars-and-v0-19-0/) took about 2 years & 3 months to accrue, whereas we hit 4k only in February this year.
 
 For me, The two most surprising figures are the docker pulls and the discord member count. 45 million is just a staggering number of docker pulls to imagine. I know there's a massive amount of automation in that area leading to such an inflated figure but I still double take when seeing it.
 

--- a/content/blog/7-years-of-bookstack.md
+++ b/content/blog/7-years-of-bookstack.md
@@ -9,7 +9,7 @@ draft = false
 date = 2022-07-12T14:25:00Z
 +++
 
-Another year goes by with BookStack now being 7 years in development from it's
+Another year goes by with BookStack now being 7 years in development from its
 original commit on the 12th of July 2015. In this post we'll continue the yearly
 tradition of reviewing the figures while exploring how this year has proved different
 to the years before it.

--- a/content/blog/beta-release-v0-20-0.md
+++ b/content/blog/beta-release-v0-20-0.md
@@ -57,7 +57,7 @@ Previously images could not be secured behind authentication like page content i
 
 Some initial work for support custom views and themes has been added. BookStack is built on Laravel and therefore uses [blade template files](https://laravel.com/docs/5.5/blade) for rendering page content. This new system allows you to selectively override any blade view file that BookStack uses without altering any original BookStack code.
 
-***Note that this feature is very early-on in it's implementation and using it in a production environment is not advised at this time.***
+***Note that this feature is very early-on in its implementation and using it in a production environment is not advised at this time.***
 
 After updating, You'll find a `themes` folder in the top-folder-level of your BookStack install. Within this folder you can create a folder, 'my-custom-theme' for example, to house your view overrides. Within your `.env` file you can then set `APP_THEME=my-custom-theme`. When loading a view BookStack will then look in your specified theme folder before then defaulting to the stock BookStack views. The view will need to match the name and folder structure as those within the `resources/views/` directory.
 

--- a/content/blog/beta-release-v0-24-0.md
+++ b/content/blog/beta-release-v0-24-0.md
@@ -59,7 +59,7 @@ With this release it's now possible to configure, per authentication option, if 
 
 This release brings quite a notable addition to BookStack's language support. Thanks to [@kmoj86](https://github.com/BookStackApp/BookStack/pull/945) Arabic is now a language choice. This is the first right-to-left language in BookStack so some functionality has been added to support right-to-left text.
 
-The WYSIWYG editor will now default it's text direction based on your language setting. In addition, If a right-to-left language is in use then additional toolbar options will show to provide control over text direction:
+The WYSIWYG editor will now default its text direction based on your language setting. In addition, If a right-to-left language is in use then additional toolbar options will show to provide control over text direction:
 
 ![wysiwyg_rtl_support.png](/images/2018/09/wysiwyg_rtl_support.png)
 

--- a/content/blog/beta-release-v0-25-1.md
+++ b/content/blog/beta-release-v0-25-1.md
@@ -19,7 +19,7 @@ removal of the Google Plus API.
 
 ### Google Sign-in Changes
 
-Google [have announced](https://developers.google.com/+/api-shutdown) the shut-down of Google+ API's which is what BookStack was using for it's Google authentication option.
+Google [have announced](https://developers.google.com/+/api-shutdown) the shut-down of Google+ API's which is what BookStack was using for its Google authentication option.
 The API's are due to be shut down on March the 7th, With API failures starting from January the 28th.
 
 In this release the API calls made no longer make use of the Google+ API so all you'll need to do is to update your BookStack instance to continue using the Google sign-in option. You should be able to continue using the same OAuth credentials as before.

--- a/content/blog/beta-release-v0-26-0.md
+++ b/content/blog/beta-release-v0-26-0.md
@@ -61,7 +61,7 @@ Previously BookStack would kind of respond to work on smaller devices but a lot 
 The header has now been updated to properly collapse down on mobile to reduce used vertical space.
 The old side drawer, containing extra details of the current view, has instead changed to a tabbed interface to save on precious horizontal space.
 
-The editing experience has been reworked to ensure its usable on mobile:
+The editing experience has been reworked to ensure it's usable on mobile:
 
 *v0.25 on the left, v0.26 on the right.*
 

--- a/content/blog/beta-release-v0-30-0.md
+++ b/content/blog/beta-release-v0-30-0.md
@@ -210,7 +210,7 @@ to the below languages by the following fantastic Crowdin & GitHub members:
 * Added warning wording around role system permissions to indicate what permissions could allow privilege escalation. ([#2105](https://github.com/BookStackApp/BookStack/issues/2105))
 * Added the ability to log login failures to a file. Thanks to [@benrubson](https://github.com/BookStackApp/BookStack/pull/1881). ([#1881](https://github.com/BookStackApp/BookStack/pull/1881), [#728](https://github.com/BookStackApp/BookStack/issues/728))
 * Updated Simplified Chinese translations. Thanks to [@Honvid](https://github.com/BookStackApp/BookStack/pull/2157). ([#2157](https://github.com/BookStackApp/BookStack/pull/2157))
-* Updated WYSIWYG editor css to put editor in it's own layer to improve degraded dark mode performance. ([#2154](https://github.com/BookStackApp/BookStack/issues/2154))
+* Updated WYSIWYG editor css to put editor in its own layer to improve degraded dark mode performance. ([#2154](https://github.com/BookStackApp/BookStack/issues/2154))
 * Updated Czech translations. Thanks to [@jakubboucek](https://github.com/BookStackApp/BookStack/pull/2238). ([#2238](https://github.com/BookStackApp/BookStack/pull/2238))
 * Updated permission system so that the permission map table does not contain ID's since database limits could be met in scenarios where permissions were automatically refreshed on a frequent basis. ([#2091](https://github.com/BookStackApp/BookStack/issues/2091))
 * Updated to role table in the database to remove a redundant name field which fixes issue where changing a role name would not change the name used to match with LDAP groups. ([#2032](https://github.com/BookStackApp/BookStack/issues/2032))

--- a/content/blog/beta-security-release-v0-30-6.md
+++ b/content/blog/beta-security-release-v0-30-6.md
@@ -20,7 +20,7 @@ You should upgrade to this released as soon as possible if you make use of page-
 
 ### Impact
 
-If a chapter was visible to a user, but all of it's pages were made not visible, then the details of these pages could be visible. Within the BookStack interface, the names of the pages and preview content could be seen. If the parent book was exported then this would include the content of the pages that had been restricted.
+If a chapter was visible to a user, but all of its pages were made not visible, then the details of these pages could be visible. Within the BookStack interface, the names of the pages and preview content could be seen. If the parent book was exported then this would include the content of the pages that had been restricted.
 
 ### Patches
 

--- a/content/blog/bookstack-release-v21-08.md
+++ b/content/blog/bookstack-release-v21-08.md
@@ -189,7 +189,7 @@ since the initial v21.05 release:
 * Improved audit log user select list stability. ([#2863](https://github.com/BookStackApp/BookStack/issues/2863))
 * Fixed incorrect styling of favourites sidebar when using a non-default homepage option. ([#2783](https://github.com/BookStackApp/BookStack/issues/2783))
 * Fixed issue where empty HTML comments could cause errors. ([#2804](https://github.com/BookStackApp/BookStack/issues/2804))
-* Extracted not found text into it's own view for easier overridding ([58117bc](https://github.com/BookStackApp/BookStack/commit/58117bcf2d91b72620de3e34b0daa705da519f5e))
+* Extracted not found text into its own view for easier overridding ([58117bc](https://github.com/BookStackApp/BookStack/commit/58117bcf2d91b72620de3e34b0daa705da519f5e))
 * Fixed issue where translations system may attempt to load from the root directory when a theme was not in use. ([#2836](https://github.com/BookStackApp/BookStack/issues/2836))
 * Fixed issue where user profile pages item "View All" links used ids hence did not link to proper searches. ([#2857](https://github.com/BookStackApp/BookStack/issues/2857))
 

--- a/content/blog/bookstack-release-v22-10.md
+++ b/content/blog/bookstack-release-v22-10.md
@@ -111,7 +111,7 @@ performing the copy has permission to edit those shelves (Since they'd effective
 
 Within the WYSIWYG editor it's always been tricky to edit code blocks on mobile, since it's usually done via a double-click
 which is often not possible on mobile browsers. This wasn't much of a problem before since the code editor popup was 
-very mobile unfriendly anyway but, with recent improvements to editing code its now more likely that users may edit code 
+very mobile unfriendly anyway but, with recent improvements to editing code it's now more likely that users may edit code 
 on such devices.
 
 To help access code blocks for edit, a toolbar will now show when a code block is selected with an action that will 

--- a/content/blog/bookstack-support-services.md
+++ b/content/blog/bookstack-support-services.md
@@ -19,7 +19,7 @@ These services are primarily intended to service business BookStack users that n
 of guaranteed, and/or official, support offering to make BookStack viable in their environment.
 Our plans offer an outlet for the IT team of a company to contact directly with an assurance of official support.
 
-Over the last couple of years I have heard multiple accounts of management discounting BookStack due to it's
+Over the last couple of years I have heard multiple accounts of management discounting BookStack due to its
 lack of obvious income routes, skeptical the project may disappear at any moment.
 Upon that I have received an increasing amount of enquiries regarding provision of support, in addition to requests for deeper
 hands-on-help via video calls. 

--- a/content/blog/replacing-ga-and-mailchimp.md
+++ b/content/blog/replacing-ga-and-mailchimp.md
@@ -37,7 +37,7 @@ pages and options so it must be inferior right? But I thought about the question
 * When does a traffic spike occur?
 
 Plausible answers all of these, and it does so directly, in an easy and beautiful UI.
-It's simplicity actually makes it better for the questions I need answered since I no longer
+Its simplicity actually makes it better for the questions I need answered since I no longer
 need to navigate through the slow, confusing interface that Google Analytics presents.
 It's all just there in a single view.
 

--- a/content/blog/services-we-use.md
+++ b/content/blog/services-we-use.md
@@ -91,7 +91,7 @@ making your life easier in the process.
 I added to the project out of curiosity a few years ago and have since left active
 after getting a surprising amount of value back. Code Climate provides code quality
 analysis, highlighting potential maintainability issues in code. 
-I don't follow it's guidance religiously but it's proved useful to get a feel
+I don't follow its guidance religiously but it's proved useful to get a feel
 when particular files might be getting out of control. 
 
 CodeClimate is not open source but it does provide free services to Open Source

--- a/content/docs/admin/debugging.md
+++ b/content/docs/admin/debugging.md
@@ -77,7 +77,7 @@ If certain dynamic elements, like dropdown menus or section tabs, are not workin
 may be other scripts interfering with BookStack's JavaScript code.
 
 - Check that the `APP_URL` option is set in your `.env` file and ensure it matches the URL you're accessing BookStack on (Including the "https://" or "http://" component).
-- If using Cloudflare, with it's DNS proxy feature, ensure that ["Rocket Loader" is disabled](https://developers.cloudflare.com/fundamentals/speed/rocket-loader/enable/).
+- If using Cloudflare, with its DNS proxy feature, ensure that ["Rocket Loader" is disabled](https://developers.cloudflare.com/fundamentals/speed/rocket-loader/enable/).
 - Check your "Custom HTML Head Content" customization setting and, if existing, temporarily remove any code in this setting to ensure it's not interfering. 
 - Use your browser developer tools to check the development console, and see if any errors exist.
 

--- a/content/docs/admin/security.md
+++ b/content/docs/admin/security.md
@@ -126,7 +126,7 @@ These are hashed using the standard Laravel hashing methods which use the Bcrypt
 
 ### JavaScript in Page Content
 
-By default, JavaScript tags within page content is escaped when rendered. This can be turned off by setting `ALLOW_CONTENT_SCRIPTS=true` in your `.env` file. Note that even if you disable this escaping the WYSIWYG editor may still perform it's own JavaScript escaping. This option will also alter the [CSP rules](#content-security-policy-csp) set by BookStack.
+By default, JavaScript tags within page content is escaped when rendered. This can be turned off by setting `ALLOW_CONTENT_SCRIPTS=true` in your `.env` file. Note that even if you disable this escaping the WYSIWYG editor may still perform its own JavaScript escaping. This option will also alter the [CSP rules](#content-security-policy-csp) set by BookStack.
 
 ***This option disables some fundamental cross-site-scripting protections. Only use this option on secure instances, where only very trusted users can edit content***
 

--- a/content/docs/admin/updates.md
+++ b/content/docs/admin/updates.md
@@ -218,7 +218,7 @@ systemctl restart apache2
 
 #### Updating to v0.30.6, v0.30.7 or higher
 
-**Security** - v0.30.6 and v0.30.7 both address issues where page content could be visible to those without permission. If a chapter was visible to a user, but all of it's pages were made not visible, then the details of these pages could be visible. Within the BookStack interface, the names of the pages and preview content could be seen. If the parent book was exported then this would include the content of the pages that had been restricted. If using BookStack v0.30.6, then all non-visible page content could be visible in plaintext exports. Please see the blog release pages for more details: [v0.30.6](/blog/beta-release-v0-30-6/), [v0.30.7](/blog/beta-release-v0-30-7/).
+**Security** - v0.30.6 and v0.30.7 both address issues where page content could be visible to those without permission. If a chapter was visible to a user, but all of its pages were made not visible, then the details of these pages could be visible. Within the BookStack interface, the names of the pages and preview content could be seen. If the parent book was exported then this would include the content of the pages that had been restricted. If using BookStack v0.30.6, then all non-visible page content could be visible in plaintext exports. Please see the blog release pages for more details: [v0.30.6](/blog/beta-release-v0-30-6/), [v0.30.7](/blog/beta-release-v0-30-7/).
 
 #### Updating to v0.30.5 or higher
 

--- a/themes/bookstack/layouts/index.html
+++ b/themes/bookstack/layouts/index.html
@@ -130,7 +130,7 @@
             <div class="col-sm-4" >
                 <h4><span class="icon" aria-hidden="true">{{partial "icon/dark-mode.svg"}}</span>Dark & Light Modes</h4>
                 <p>
-                   BookStack provides it's user interface in both a light theme and a dark theme, saving the eyes
+                   BookStack provides its user interface in both a light theme and a dark theme, saving the eyes
                    of those that prefer to work in the shadows. This is configurable at a user level.
                 </p>
             </div>


### PR DESCRIPTION
Just a small PR to fix some places where "it's" and "its" were being used incorrectly.