### PR TITLE
updates.md: Add command to clear all caches on update

### DIFF
--- a/content/docs/admin/updates.md
+++ b/content/docs/admin/updates.md
@@ -20,12 +20,10 @@ php artisan migrate
 
 This first command will update the repository that was created in the installation. The second will install the PHP dependencies using `composer`. The third will then update the database with any required changes.
 
-In addition, Clearing the system caches is also recommended:
+In addition, clearing all the caches used by system is also recommended:
 
 ```bash
-php artisan cache:clear
-php artisan config:clear
-php artisan view:clear
+php artisan optimize:clear
 ```
 
 Check the below [Version Specific Instructions](#version-specific-instructions) list for the version you are updating to for any additional instructions.


### PR DESCRIPTION
Motivated by an issue noticed on my instance of BookStack when updating from  v23.05 to v23.08.3 

```
[previous exception] [object] (ReflectionException(code: -1): Class \"BookStack\\Http\\Controllers\\HomeController\" does not exist at /var/www/docs.thecurlybraces.com/public_html/vendor/laravel/framework/src/Illuminate/Container/Container.php:889)
```
The `HomeController` was moved in [141eecb858cce126452baeb16905e25b6ceb13c6](https://github.com/BookStackApp/BookStack/commit/141eecb858cce126452baeb16905e25b6ceb13c6)