### PR TITLE
Update Editor shortcuts for Markdown and WYSIWYG editor docs

### DIFF
--- a/content/docs/user/markdown-editor.md
+++ b/content/docs/user/markdown-editor.md
@@ -76,7 +76,7 @@ The following shortcuts are available in the Markdown Editor:
     </tr>
     <tr>
       <td><code>Ctrl+9</code> / <code>Cmd+9</code></td>
-      <td>Callout (Info)</td>
+      <td>Callout (Keep pressing to toggle through styles info, success, warning, danger)</td>
     </tr>
     <tr>
       <td>
@@ -91,11 +91,11 @@ The following shortcuts are available in the Markdown Editor:
     </tr>
     <tr>
       <td><code>Ctrl+Shift+K</code> / <code>Cmd+Shift+K</code></td>
-      <td>Show link selector</td>
+      <td>Link to BookStack content</td>
     </tr>
     <tr>
       <td><code>Ctrl+Shift+I</code> / <code>Cmd+Shift+I</code></td>
-      <td>Insert Image</td>
+      <td>Insert Image via URL</td>
     </tr>
   </tbody>
 </table>

--- a/content/docs/user/wysiwyg-editor.md
+++ b/content/docs/user/wysiwyg-editor.md
@@ -72,7 +72,7 @@ The following shortcuts are available in the WYSIWYG Editor:
     </tr>
     <tr>
       <td><code>Ctrl+9</code> / <code>Cmd+9</code></td>
-      <td>Callout <br>(Keep pressing to toggle through styles)</td>
+      <td>Callout (Keep pressing to toggle through styles info, success, warning, danger)</td>
     </tr>
     <tr>
       <td>
@@ -80,6 +80,10 @@ The following shortcuts are available in the WYSIWYG Editor:
         <code>Ctrl+P</code> / <code>Cmd+P</code>
       </td>
       <td>Ordered List <br> Bullet List</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl+K</code> / <code>Cmd+K</code></td>
+      <td>Insert Link</td>
     </tr>
     <tr>
       <td><code>Ctrl+Shift+K</code> / <code>Cmd+Shift+K</code></td>


### PR DESCRIPTION
There were a couple of changes to the shortcuts not being up to date or informative. Not sure if there are any hidden shortcuts that were not listed prior to my pull request. 

Also, I'm not sure if the shortcut changes will be reflected automatically for the help popup in WYSIWYG editor.
![image](https://github.com/BookStackApp/website/assets/82655889/2b0b36dc-2cb6-4bd0-9f79-5912d728d9ad)

On a side note, it might be helpful to include a help popup to display shortcuts for markdown editor as well.